### PR TITLE
Add Java version 17 as explicit requirement in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Placeholder for bug fixes and security updates.
 
 ### Changed
-- Placeholder for changes to existing functionality.
+- Added line to README.md about Java tests failing on versions older than 17
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ git clone https://github.com/National-Digital-Twin/jena-fuseki-kafka.git
 cd jena-fuseki-kafka
 ```
 ### 2. Run Build Version  
+This requires Java 17. Tests will currently fail if run on later Java versions. This also applies to `mvn test`
 ```sh  
 mvn clean package
 
@@ -84,6 +85,13 @@ To use the library directly in your project:
 ```
 
 _populate the `artifactId` above as appropriate._
+
+### 4. Testing
+You can run the test suite with
+```sh
+mvn test
+```
+Requires Java 17. There have been reports of failures when running on newer Java versions
 
 ## Features  
 - **Key functionality**  


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
This PR fixes a gap in the documentation where it wasn't made clear enough that running the tests in this repository would fail on newer versions of Java. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description

- Updated README.md with explicit instructions to run build and test commands with Java 17, warning that future versions of Java will cause these commands to fail

## How Has This Been Tested?
N/A - This is a documentation change
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.