### PR TITLE
Replace printStackTrace statements with error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Placeholder for upcoming features and enhancements.
 
 ### Fixed
-- Placeholder for bug fixes and security updates.
+- Fixed SonarQube Security Hotspot issues
 
 ### Changed
 - Added line to README.md about Java tests failing on versions older than 17

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKProcessorBaseAction.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKProcessorBaseAction.java
@@ -37,6 +37,8 @@ import org.apache.jena.kafka.ResponseFK;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.riot.WebContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Process incoming request as a SPARQL Update, RDF Patch or RDF data as appropriate.
@@ -50,6 +52,8 @@ import org.apache.jena.riot.WebContent;
  * <ul>
  */
 public abstract class FKProcessorBaseAction implements FKProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FKProcessorBaseAction.class);
 
     protected FKProcessorBaseAction() {}
 
@@ -106,7 +110,7 @@ public abstract class FKProcessorBaseAction implements FKProcessor {
     }
 
     protected void actionFailed(RuntimeException ex) {
-        ex.printStackTrace();
+        LOGGER.error(ex.getMessage(), ex);
     }
 
     protected abstract void actionSparqlUpdate(String id, RequestFK request, InputStream data);

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/FKLib.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/FKLib.java
@@ -59,6 +59,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FKLib {
 
@@ -66,6 +67,7 @@ public class FKLib {
         throw new IllegalStateException("Utility class");
     }
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FKLib.class);
     private static Logger LOG = FusekiKafka.LOG;
 
     // -- send file
@@ -152,9 +154,9 @@ public class FKLib {
             return res;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            e.printStackTrace();
+            LOGGER.error(e.getMessage(), e);
         } catch (ExecutionException e) {
-            e.printStackTrace();
+            LOGGER.error(e.getMessage(), e);
         }
 
         return null;

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/FKLib.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/FKLib.java
@@ -63,12 +63,12 @@ import org.slf4j.LoggerFactory;
 
 public class FKLib {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FKLib.class);
+    private static Logger LOG = FusekiKafka.LOG;
+
     private FKLib() {
         throw new IllegalStateException("Utility class");
     }
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FKLib.class);
-    private static Logger LOG = FusekiKafka.LOG;
 
     // -- send file
     public static String  ctForFile(String fn) {

--- a/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_Send.java
+++ b/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_Send.java
@@ -53,6 +53,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Send one file. */
 // Suppress SonarQube rule S110: This class has 6 parents which is greater than 5 authorized.
@@ -73,6 +75,9 @@ public class FK_Send extends CmdGeneral {
     public static void main(String... args) {
         new FK_Send(args).mainRun() ;
     }
+
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FK_Send.class);
 
     private String server = null;
     private String topic = null;
@@ -123,9 +128,9 @@ public class FK_Send extends CmdGeneral {
             return f.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            e.printStackTrace();
+            LOGGER.error(e.getMessage(), e);
         } catch (ExecutionException e) {
-            e.printStackTrace();
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -142,7 +142,7 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         try {
             return createSub(graph, node);
         } catch (RuntimeException ex) {
-            ex.printStackTrace();
+            LOGGER.error(ex.getMessage(), ex);
             return null;
         }
     }


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As part of preparing IA Node & Federator to a suitable standard we have identified via SonarQube some issues and the steps required to resolve them

Blocker issue identified : overview from SonarQube

Make sure this debug feature is deactivated before delivering the code in production

6 low priority warnings to make sure debug feature is deactivated before deploying to production

The cause of these warnings are `printStackTrace()` lines which print the error stack trace. We want to replace this with logger messages. 


## Description

- This PR replaces instances of `printStackTrace` with logger error messages, to resolve the SonarQube security hotspot issues

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

### Prerequisites

- Ensure you have configured your `settings.xml` as shown in the **Maven setup** setup section [here](https://github.com/National-Digital-Twin/federator/blob/main/docs/running-locally.md#maven-setup).
- Java 17 installed.
- Maven installed.
- Docker installed.

### To Test
- Pull branch locally.
- Don't forget to switch to Java 17. Check with `java --version` **and** `mvn --version`.
- Add this line to line 304 of your `pom.xml` file, in between `</argLine>` and `</configuration>`:
```
<testFailureIgnore>true</testFailureIgnore>
```
- Run the following command to spin up a specific Sonarqube istance locally.
```
docker run -p 9000:9000 -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true --name sonarqube sonarqube:25.5.0.107428-community
```
- Go to dashboard at **`http://localhost_9000`**.
- Use **`admin`** as the username and **`admin`** as the password initially.
- A new screen will require the setting of a new password, complete this.
> [!TIP]
> If you get `Unexpected Application Error!` refresh the page (it seems to be to do with the overlay not rendering properly) and then dismiss the modal that will pop up.
- Select **`Create a local project`** and fill in the required fields. For branch name, it should reflect the branch that the scan is being ran on.
- On the **`Set up project for Clean as You Code`** select **`Use the global setting`** and click on progress to the next page.
- On the **`Analysis Method`** page, scroll to the bottom and select **`Locally`**.
- Enter a token name and clean **`Generate`**.
- On the next page, click on **`Continue`**.
- Under **`Run analysis on your project`**, select **`Maven`**. You will be presented with the command to run to initiate a scan.
- Copy the command you are provided in the following format
```
mvn clean verify sonar:sonar \
  -Dsonar.projectKey=jena-fuseki-kafka \
  -Dsonar.projectName='auto_populated' \
  -Dsonar.host.url=http://localhost:9000 \
  -Dsonar.token={your_sonarqube_token} 
```



## Screenshots (if appropriate):
![Screenshot 2025-06-06 at 16 04 12](https://github.com/user-attachments/assets/8f31722c-edf1-4dd5-9b7b-8323b7866549)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.